### PR TITLE
2.0

### DIFF
--- a/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
+++ b/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.1"></a>
+## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.0...@monorepo-utils/collect-changelog@2.0.1) (2018-08-07)
+
+
+
+
+**Note:** Version bump only for package @monorepo-utils/collect-changelog
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@1.2.0...@monorepo-utils/collect-changelog@2.0.0) (2018-08-07)
 

--- a/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
+++ b/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@1.2.0...@monorepo-utils/collect-changelog@2.0.0) (2018-08-07)
+
+
+### Bug Fixes
+
+* **package-utils:** change `package` to `packageJSON` ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))
+
+
+### BREAKING CHANGES
+
+* **package-utils:** the result `package` to be `packageJSON`
+
+
+
+
 <a name="1.2.0"></a>
 # [1.2.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@1.1.0...@monorepo-utils/collect-changelog@1.2.0) (2018-07-22)
 

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/collect-changelog",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Collect CHANGELOG from tags.",
   "keywords": [
     "changelog",
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.0",
+    "@monorepo-utils/package-utils": "^2.0.1",
     "cclog-parser": "^1.1.0",
     "changelog-parser": "^2.1.0",
     "handlebars": "^4.0.11",

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/collect-changelog",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Collect CHANGELOG from tags.",
   "keywords": [
     "changelog",
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^1.1.0",
+    "@monorepo-utils/package-utils": "^2.0.0",
     "cclog-parser": "^1.1.0",
     "changelog-parser": "^2.1.0",
     "handlebars": "^4.0.11",

--- a/packages/@monorepo-utils/package-utils/CHANGELOG.md
+++ b/packages/@monorepo-utils/package-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.1"></a>
+## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@2.0.0...@monorepo-utils/package-utils@2.0.1) (2018-08-07)
+
+
+
+
+**Note:** Version bump only for package @monorepo-utils/package-utils
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@1.1.0...@monorepo-utils/package-utils@2.0.0) (2018-08-07)
 

--- a/packages/@monorepo-utils/package-utils/CHANGELOG.md
+++ b/packages/@monorepo-utils/package-utils/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@1.1.0...@monorepo-utils/package-utils@2.0.0) (2018-08-07)
+
+
+### Bug Fixes
+
+* **package-utils:** change `package` to `packageJSON` ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))
+
+
+### BREAKING CHANGES
+
+* **package-utils:** the result `package` to be `packageJSON`
+
+
+
+
 <a name="1.1.0"></a>
 # 1.1.0 (2018-07-22)
 

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/package-utils",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Package utility for monorepo.",
   "keywords": [
     "lerna",

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/package-utils",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Package utility for monorepo.",
   "keywords": [
     "lerna",

--- a/packages/@monorepo-utils/package-utils/src/get-packages.ts
+++ b/packages/@monorepo-utils/package-utils/src/get-packages.ts
@@ -44,6 +44,7 @@ export interface PackageResult {
 
 export const getPackages = (rootDirectory: string): PackageResult[] => {
     const lernaJsonPath = path.join(rootDirectory, "lerna.json");
+    // prefer to use yarn workspace instead of lerna.json
     if (fs.existsSync(lernaJsonPath)) {
         const lernaJson = loadJsonFile.sync(lernaJsonPath);
         if (!lernaJson.useWorkspaces) {

--- a/packages/@monorepo-utils/publish/CHANGELOG.md
+++ b/packages/@monorepo-utils/publish/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.1"></a>
+## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@2.0.0...@monorepo-utils/publish@2.0.1) (2018-08-07)
+
+
+### Bug Fixes
+
+* **publish:** update timeout length ([fc2d4ce](https://github.com/azu/monorepo-utils/commit/fc2d4ce))
+
+
+
+
 <a name="2.0.0"></a>
 # [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@1.3.2...@monorepo-utils/publish@2.0.0) (2018-08-07)
 

--- a/packages/@monorepo-utils/publish/CHANGELOG.md
+++ b/packages/@monorepo-utils/publish/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@1.3.2...@monorepo-utils/publish@2.0.0) (2018-08-07)
+
+
+### Bug Fixes
+
+* **package-utils:** change `package` to `packageJSON` ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))
+
+
+### BREAKING CHANGES
+
+* **package-utils:** the result `package` to be `packageJSON`
+
+
+
+
 <a name="1.3.2"></a>
 ## [1.3.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@1.3.1...@monorepo-utils/publish@1.3.2) (2018-08-06)
 

--- a/packages/@monorepo-utils/publish/package.json
+++ b/packages/@monorepo-utils/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/publish",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Publish packages to npm if needed. ",
   "license": "MIT",
   "files": [
@@ -20,7 +20,7 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.0",
+    "@monorepo-utils/package-utils": "^2.0.1",
     "can-npm-publish": "^1.3.1",
     "chalk": "^2.3.0",
     "child-process-promise": "^2.2.1",

--- a/packages/@monorepo-utils/publish/package.json
+++ b/packages/@monorepo-utils/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/publish",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "description": "Publish packages to npm if needed. ",
   "license": "MIT",
   "files": [
@@ -20,7 +20,7 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^1.1.0",
+    "@monorepo-utils/package-utils": "^2.0.0",
     "can-npm-publish": "^1.3.1",
     "chalk": "^2.3.0",
     "child-process-promise": "^2.2.1",

--- a/packages/@monorepo-utils/publish/test/publish-test.ts
+++ b/packages/@monorepo-utils/publish/test/publish-test.ts
@@ -3,6 +3,7 @@ import { publish } from "../src/publish";
 
 const stripAnsi = require("strip-ansi");
 const makeConsoleMock = require("consolemock");
+jest.setTimeout(10000); // 10 second timeout
 describe("publish", () => {
     let consoleMock: any;
     let originalConsole: any;


### PR DESCRIPTION
## @monorepo-utils/collect-changelog@2.0.0

### fixes

- **package-utils:** change &#x60;package&#x60; to &#x60;packageJSON&#x60; ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))

### breakingChanges

- **package-utils:** the result &#x60;package&#x60; to be &#x60;packageJSON&#x60;


## @monorepo-utils/package-utils@2.0.0

### fixes

- **package-utils:** change &#x60;package&#x60; to &#x60;packageJSON&#x60; ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))

### breakingChanges

- **package-utils:** the result &#x60;package&#x60; to be &#x60;packageJSON&#x60;


## @monorepo-utils/publish@2.0.0

### fixes

- **package-utils:** change &#x60;package&#x60; to &#x60;packageJSON&#x60; ([ae6ddf3](https://github.com/azu/monorepo-utils/commit/ae6ddf3))

### breakingChanges

- **package-utils:** the result &#x60;package&#x60; to be &#x60;packageJSON&#x60;




Related #12 

