### PR TITLE
Release @monorepo-utils/collect-changelog@2.0.2

### DIFF
--- a/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
+++ b/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.0...@monorepo-utils/collect-changelog@2.0.2) (2019-01-16)
+
+
+### Bug Fixes
+
+* **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
+
+
+
+
+
 <a name="2.0.1"></a>
 ## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.0...@monorepo-utils/collect-changelog@2.0.1) (2018-08-07)
 

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@monorepo-utils/package-utils": "^2.0.2",
-    "cclog-parser": "^1.1.0",
+    "cclog-parser": "^1.1.1",
     "changelog-parser": "^2.6.0",
     "handlebars": "^4.0.12",
     "meow": "^5.0.0"

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/collect-changelog",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Collect CHANGELOG from tags.",
   "keywords": [
     "changelog",
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.1",
+    "@monorepo-utils/package-utils": "^2.0.2",
     "cclog-parser": "^1.1.0",
     "changelog-parser": "^2.6.0",
     "handlebars": "^4.0.12",

--- a/packages/@monorepo-utils/package-utils/CHANGELOG.md
+++ b/packages/@monorepo-utils/package-utils/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@2.0.0...@monorepo-utils/package-utils@2.0.2) (2019-01-16)
+
+
+### Bug Fixes
+
+* **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
+
+
+
+
+
 <a name="2.0.1"></a>
 ## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@2.0.0...@monorepo-utils/package-utils@2.0.1) (2018-08-07)
 

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/package-utils",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Package utility for monorepo.",
   "keywords": [
     "lerna",

--- a/packages/@monorepo-utils/publish/CHANGELOG.md
+++ b/packages/@monorepo-utils/publish/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@2.0.0...@monorepo-utils/publish@2.0.2) (2019-01-16)
+
+
+### Bug Fixes
+
+* **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
+* **publish:** update timeout length ([fc2d4ce](https://github.com/azu/monorepo-utils/commit/fc2d4ce))
+
+
+
+
+
 <a name="2.0.1"></a>
 ## [2.0.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@2.0.0...@monorepo-utils/publish@2.0.1) (2018-08-07)
 

--- a/packages/@monorepo-utils/publish/package.json
+++ b/packages/@monorepo-utils/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/publish",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Publish packages to npm if needed. ",
   "license": "MIT",
   "files": [
@@ -20,7 +20,7 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.1",
+    "@monorepo-utils/package-utils": "^2.0.2",
     "can-npm-publish": "^1.3.1",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,9 +1294,10 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
 
-cclog-parser@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/cclog-parser/-/cclog-parser-1.1.0.tgz#2643d9fe24966b9e8616448ae4570bc1877841f7"
+cclog-parser@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/cclog-parser/-/cclog-parser-1.1.1.tgz#44425a21a458f44985121c04912e5e02d1f04fab"
+  integrity sha512-IsnWRC1zqs7h5+Xoocw7cYmlL5t2ysB0/SQB6C3Arr+S2pc2Rbhzp0hXaK36Ew+428in1085slsGtxsJwQB9RA==
 
 center-align@^0.1.1:
   version "0.1.3"


### PR DESCRIPTION
## @monorepo-utils/collect-changelog@2.0.2

### fixes

- **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
## @monorepo-utils/package-utils@2.0.2

### fixes

- **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
## @monorepo-utils/publish@2.0.2

### fixes

- **collect-changelog:** ignore empty changelog ([#16](https://github.com/azu/monorepo-utils/issues/16)) ([0ef9f29](https://github.com/azu/monorepo-utils/commit/0ef9f29))
- **publish:** update timeout length ([fc2d4ce](https://github.com/azu/monorepo-utils/commit/fc2d4ce))
