### PR TITLE
Release 2019 01 22

### DIFF
--- a/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
+++ b/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.1.1](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.1.0...@monorepo-utils/collect-changelog@2.1.1) (2019-01-22)
+
+
+### Bug Fixes
+
+* **collect-changelog:** fix cmd to use correct option ([17a2db1](https://github.com/azu/monorepo-utils/commit/17a2db1))
+
+
+
+
+
 # [2.1.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.2...@monorepo-utils/collect-changelog@2.1.0) (2019-01-22)
 
 

--- a/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
+++ b/packages/@monorepo-utils/collect-changelog/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.1.0](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.2...@monorepo-utils/collect-changelog@2.1.0) (2019-01-22)
+
+
+### Features
+
+* **collect-changelog:** support --changelog option for fixed mode ([51226af](https://github.com/azu/monorepo-utils/commit/51226af))
+
+
+
+
+
 ## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/collect-changelog@2.0.0...@monorepo-utils/collect-changelog@2.0.2) (2019-01-16)
 
 

--- a/packages/@monorepo-utils/collect-changelog/bin/cmd.js
+++ b/packages/@monorepo-utils/collect-changelog/bin/cmd.js
@@ -45,7 +45,7 @@ const promises = cli.input.map(tag => {
     return execute({
         changelogFilePath,
         directory: monorepoDirectory,
-        lernaTag: tag,
+        tag: tag,
         templatePath: cli.flags.template
     });
 });

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/collect-changelog",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "Collect CHANGELOG from tags.",
   "keywords": [
     "changelog",
@@ -62,7 +62,7 @@
     }
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.2",
+    "@monorepo-utils/package-utils": "^2.0.3",
     "cclog-parser": "^1.1.1",
     "changelog-parser": "^2.6.0",
     "handlebars": "^4.0.12",

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/collect-changelog",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Collect CHANGELOG from tags.",
   "keywords": [
     "changelog",

--- a/packages/@monorepo-utils/package-utils/CHANGELOG.md
+++ b/packages/@monorepo-utils/package-utils/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.3](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@2.0.2...@monorepo-utils/package-utils@2.0.3) (2019-01-22)
+
+**Note:** Version bump only for package @monorepo-utils/package-utils
+
+
+
+
+
 ## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/package-utils@2.0.0...@monorepo-utils/package-utils@2.0.2) (2019-01-16)
 
 

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/package-utils",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Package utility for monorepo.",
   "keywords": [
     "lerna",

--- a/packages/@monorepo-utils/publish/CHANGELOG.md
+++ b/packages/@monorepo-utils/publish/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.3](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@2.0.2...@monorepo-utils/publish@2.0.3) (2019-01-22)
+
+**Note:** Version bump only for package @monorepo-utils/publish
+
+
+
+
+
 ## [2.0.2](https://github.com/azu/monorepo-utils/compare/@monorepo-utils/publish@2.0.0...@monorepo-utils/publish@2.0.2) (2019-01-16)
 
 

--- a/packages/@monorepo-utils/publish/package.json
+++ b/packages/@monorepo-utils/publish/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorepo-utils/publish",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Publish packages to npm if needed. ",
   "license": "MIT",
   "files": [
@@ -20,7 +20,7 @@
     "watch": "tsc -p . --watch"
   },
   "dependencies": {
-    "@monorepo-utils/package-utils": "^2.0.2",
+    "@monorepo-utils/package-utils": "^2.0.3",
     "can-npm-publish": "^1.3.1",
     "chalk": "^2.4.2",
     "child-process-promise": "^2.2.1",


### PR DESCRIPTION
﻿## @monorepo-utils/collect-changelog@2.1.1

### features

- **collect-changelog:** add `--changelog` option #19 

### fixes

- **collect-changelog:** fix cmd to use correct option ([17a2db1](https://github.com/azu/monorepo-utils/commit/17a2db1))
