### PR TITLE
fix: use upath instead of path

### DIFF
--- a/packages/@monorepo-utils/collect-changelog/bin/cmd.js
+++ b/packages/@monorepo-utils/collect-changelog/bin/cmd.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 const meow = require("meow");
-const path = require("path");
+const path = require("upath");
 const execute = require("../lib/cli").execute;
 
 const cli = meow(

--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -67,7 +67,8 @@
     "cclog-parser": "^1.1.1",
     "changelog-parser": "^2.6.0",
     "handlebars": "^4.0.12",
-    "meow": "^7.1.1"
+    "meow": "^7.1.1",
+    "upath": "^2.0.0"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.40",

--- a/packages/@monorepo-utils/collect-changelog/src/cli.ts
+++ b/packages/@monorepo-utils/collect-changelog/src/cli.ts
@@ -3,7 +3,7 @@
 
 import * as fs from "fs";
 
-import * as path from "path";
+import * as path from "upath";
 import { findChangelog, getChangelog } from "./collect-changelog-from-tag";
 import Handlebars = require("handlebars");
 

--- a/packages/@monorepo-utils/collect-changelog/src/collect-changelog-from-tag.ts
+++ b/packages/@monorepo-utils/collect-changelog/src/collect-changelog-from-tag.ts
@@ -1,6 +1,6 @@
 // MIT © 2017 azu
 "use strict";
-import * as path from "path";
+import * as path from "upath";
 import * as fs from "fs";
 import { getPackages } from "@monorepo-utils/package-utils";
 

--- a/packages/@monorepo-utils/collect-changelog/test/cli-test.ts
+++ b/packages/@monorepo-utils/collect-changelog/test/cli-test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "upath";
 import { execute } from "../src/cli";
 
 const independentDir = path.join(__dirname, "fixtures/independent");

--- a/packages/@monorepo-utils/collect-changelog/test/collect-changelog-from-tag-test.ts
+++ b/packages/@monorepo-utils/collect-changelog/test/collect-changelog-from-tag-test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "upath";
 import { findChangelog } from "../src/collect-changelog-from-tag";
 describe("collect-changelog-from-tag", () => {
     it("should match package@version", async () => {

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -62,7 +62,8 @@
   },
   "dependencies": {
     "globby": "^11.0.1",
-    "load-json-file": "^6.2.0"
+    "load-json-file": "^6.2.0",
+    "upath": "^2.0.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.10",

--- a/packages/@monorepo-utils/package-utils/src/get-packages.ts
+++ b/packages/@monorepo-utils/package-utils/src/get-packages.ts
@@ -3,7 +3,7 @@
 // MIT (c) 2018 Lucas Azzola
 const globby = require("globby");
 import loadJsonFile = require("load-json-file");
-import * as path from "path";
+import * as path from "upath";
 import * as fs from "fs";
 
 const loadPackage = (packagePath: string): object => {

--- a/packages/@monorepo-utils/package-utils/test/get-packages-test.ts
+++ b/packages/@monorepo-utils/package-utils/test/get-packages-test.ts
@@ -1,4 +1,4 @@
-import * as path from "path";
+import * as path from "upath";
 import { getPackages } from "../src";
 
 expect.addSnapshotSerializer({

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/package.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/package.json
@@ -70,7 +70,8 @@
   "dependencies": {
     "@monorepo-utils/package-utils": "^2.2.0",
     "comment-json": "^3.0.3",
-    "meow": "^7.1.1"
+    "meow": "^7.1.1",
+    "upath": "^2.0.0"
   },
   "devDependencies": {
     "@types/comment-json": "^1.1.1",

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/cli.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/cli.ts
@@ -1,5 +1,5 @@
 import meow from "meow";
-import path from "path";
+import path from "upath";
 import { toProjectReferences } from "./index";
 
 export const cli = meow(

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import path from "path";
+import path from "upath";
 import commentJSON from "comment-json";
 import { plugin as workspacesPlugin } from "./manager/workspaces";
 import assert from "assert";

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "upath";
 import { toProjectReferences } from "../src";
 
 describe("toProjectReferences", function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7276,6 +7276,11 @@ upath@^1.2.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
+upath@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.0.tgz#7234f3c1e7fd2bcb4f6aaba3e5565ee13ce6d287"
+  integrity sha512-ghi1XxsVYPOZPDsOZrfOJIwQU5I3JVYB3Q6IbBGn1KFeOa89i0nUy5tCEkY9pVm83U83qZ1QG40RQKGknllV4w==
+
 uri-js@^4.2.2:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.3.0.tgz#e16cb9ef7b4036d74be59dc7342258e6f1aca20e"


### PR DESCRIPTION
Fixes #31.

I've changed the usages of `path` to `upath` in all projects except deprecated (in the `archive` directory) for consistency.

However, the code works but the tests don't work on Windows because [`instanceof` is broken in `jest`](https://github.com/facebook/jest/issues/2549), and tests use the original `path` module. :disappointed: 

More details:
- `upath` creates a proxy around the `path` object. It proxies every function and [this check is based on `instanceof`](https://github.com/anodynos/upath/blob/master/source/code/upath.coffee#L3)
- `jest` provides context isolation so tests can't have side-effects on other tests by manipulating the global context. But this means that [global variables like `Function` differ and `instanceof` is broken](https://github.com/facebook/jest/issues/2549). :cry: 

I hope you have a better solution and I'll be glad to help.

Sure, I can use just the `string.replace` before the `globby` call but I'm afraid of inconsistency.