### PR TITLE
Update upath

### DIFF
--- a/packages/@monorepo-utils/collect-changelog/package.json
+++ b/packages/@monorepo-utils/collect-changelog/package.json
@@ -68,7 +68,7 @@
     "changelog-parser": "^2.6.0",
     "handlebars": "^4.0.12",
     "meow": "^7.1.1",
-    "upath": "^2.0.0"
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@types/handlebars": "^4.0.40",

--- a/packages/@monorepo-utils/package-utils/package.json
+++ b/packages/@monorepo-utils/package-utils/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "globby": "^11.0.1",
     "load-json-file": "^6.2.0",
-    "upath": "^2.0.0"
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.10",

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/package.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/package.json
@@ -71,7 +71,7 @@
     "@monorepo-utils/package-utils": "^2.2.1",
     "comment-json": "^3.0.3",
     "meow": "^7.1.1",
-    "upath": "^2.0.0"
+    "upath": "^2.0.1"
   },
   "devDependencies": {
     "@types/comment-json": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7276,10 +7276,10 @@ upath@^1.2.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-upath@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.0.tgz#7234f3c1e7fd2bcb4f6aaba3e5565ee13ce6d287"
-  integrity sha512-ghi1XxsVYPOZPDsOZrfOJIwQU5I3JVYB3Q6IbBGn1KFeOa89i0nUy5tCEkY9pVm83U83qZ1QG40RQKGknllV4w==
+upath@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
+  integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
 uri-js@^4.2.2:
   version "4.3.0"


### PR DESCRIPTION
The [issue](https://github.com/anodynos/upath/issues/40) that broke the `upath` in the `jest` tests is fixed now.

This PR updates the `upath` version.

With this fix tests should work on Windows, but I can't check it (I have no Windows machines).