### PR TITLE
correct relative paths for tsconfig.json in sub-directory

### DIFF
--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
@@ -67,8 +67,9 @@ export const toProjectReferences = (options: Options) => {
                         )
                     );
                 }
+                const resolvePath = path.dirname(path.resolve(packageInfo.location, tsconfigFilePath));
                 return {
-                    path: path.relative(packageInfo.location, absolutePathOrNull)
+                    path: path.relative(resolvePath, absolutePathOrNull)
                 };
             })
             .filter((r) => Boolean(r));


### PR DESCRIPTION
# Problem
If `tsconfigPath` is under a sub-directory (eg `src/tsconfig.json`), the relative paths to the referenced projects will not be accurate as they are resolved from the package root, not the directory containing `tsconfig.json`

# Solution
Resolve the path to the referenced project from `tsconfigPath`