### PR TITLE
fix: append tsConfigPath filename without parent directories

### DIFF
--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
@@ -62,7 +62,7 @@ export const toProjectReferences = (options: Options) => {
                 // then append it to the generated path
                 const tsConfigFileName = path.basename(tsConfigPath);
                 if (tsConfigFileName !== DEFAULT_TSCONFIGPATH) {
-                    pathComponents.push(tsConfigPath);
+                    pathComponents.push(tsConfigFileName);
                 }
 
                 const absolutePath = path.join(...pathComponents);

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/a/src/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/a/src/tsconfig-esm.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig-esm.json",
+  "references": []
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/a/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/a/tsconfig-esm.json
@@ -4,6 +4,5 @@
     "moduleResolution": "node",
     "target": "ESNext",
     "strict": true
-  },
-  "references": []
+  }
 }

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/b/src/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/b/src/tsconfig-esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig-esm.json",
+  "references": [
+    {
+      "path": "../../a/src/tsconfig-esm.json"
+    }
+  ]
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/b/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/b/tsconfig-esm.json
@@ -4,10 +4,5 @@
     "moduleResolution": "node",
     "target": "ESNext",
     "strict": true
-  },
-  "references": [
-    {
-      "path": "../a/tsconfig-esm.json"
-    }
-  ]
+  }
 }

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/c/src/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/c/src/tsconfig-esm.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig-esm.json",
+  "references": [
+    {
+      "path": "../../a/src/tsconfig-esm.json"
+    },
+    {
+      "path": "../../b/src/tsconfig-esm.json"
+    }
+  ]
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/c/tsconfig-esm.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/yarn-workspaces-tsconfigPath/packages/c/tsconfig-esm.json
@@ -4,13 +4,5 @@
     "moduleResolution": "node",
     "target": "ESNext",
     "strict": true
-  },
-  "references": [
-    {
-      "path": "../a/tsconfig-esm.json"
-    },
-    {
-      "path": "../b/tsconfig-esm.json"
-    }
-  ]
+  }
 }

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
@@ -30,7 +30,7 @@ describe("toProjectReferences", function () {
         expect(result.ok).toBe(true);
     });
     it("support yarn workspaces with tsConfigPath with filename that is not tsconfig.json", () => {
-        const tsconfigPath = "tsconfig-esm.json";
+        const tsconfigPath = "src/tsconfig-esm.json";
         const customTsConfigFinder = (location: string) => {
             return path.join(location, tsconfigPath);
         };


### PR DESCRIPTION
# Problem
Cheers for the rapid merge @azu! I spotted a bug right at the lat minute but it was already merged. See here: https://github.com/azu/monorepo-utils/pull/47#issuecomment-876461385

# Solution
Fix the bug and update the test fixtures to account for this case