### PR TITLE
fix: improve check for changes

### DIFF
--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/src/index.ts
@@ -110,10 +110,14 @@ export const toProjectReferences = (options: Options) => {
             // update
             if (errors.length === 0) {
                 tsconfigJSON["references"] = newProjectReferences;
-                const oldContents = fs.readFileSync(tsconfigFilePath, { encoding: "utf-8" });
-                const newContents = `${commentJSON.stringify(tsconfigJSON, null, 2)}\n`;
+                const oldContents = commentJSON.stringify(
+                    commentJSON.parse(fs.readFileSync(tsconfigFilePath, { encoding: "utf-8" })),
+                    null,
+                    2
+                );
+                const newContents = commentJSON.stringify(tsconfigJSON, null, 2);
                 if (newContents !== oldContents) {
-                    fs.writeFileSync(tsconfigFilePath, newContents, "utf-8");
+                    fs.writeFileSync(tsconfigFilePath, `${newContents}\n`, "utf-8");
                 }
             }
         }


### PR DESCRIPTION
In one of our projects we're formatting all `package.json` files with prettier as part of a pre-commit hook (and after running `workspaces-to-typescript-project-references`).
This causes the change check of `workspaces-to-typescript-project-references` to fail because the strings it compares are different even though the JSON objects have the same contents.

As a side effect this causes `tsc -b` to take significantly longer when running after `workspaces-to-typescript-project-references` without any other code changes.

This change parses & re-stringifies the tsconfig file to make sure it has the same formatting as the new contents JSON string.