### PR TITLE
fix(project-references): add validation for duplicated deps

### DIFF
--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/lerna.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/lerna.json
@@ -1,0 +1,3 @@
+{
+  "packages": ["packages/*"]
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/invalid/package.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/invalid/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@example/invalid",
+  "version": "1.0.0",
+  "dependencies": {
+  }
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/invalid/tsconfig.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/invalid/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ESNext",
+    "strict": true
+  },
+  "references": [
+    {
+      "path": "../a"
+    }
+  ]
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/main/package.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/main/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@example/main",
+  "version": "1.0.0",
+  "dependencies": {
+    "@example/invalid": "^1.0.0"
+  },
+  "devDependencies": {
+    "@example/invalid": "^1.0.0"
+  }
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/main/tsconfig.json
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/fixtures/error.invalid-dependencies/packages/main/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ESNext",
+    "strict": true
+  },
+  "references": [
+    {
+      "path": "../invalid"
+    }
+  ]
+}

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
@@ -83,6 +83,22 @@ describe("toProjectReferences", function () {
             "
         `);
     });
+    it("ok: false when a same package in `dependencies` and `devDependencies`", () => {
+        const result = toProjectReferences({
+            rootDir: path.join(__dirname, "fixtures/error.invalid-dependencies"),
+            checkOnly: true
+        });
+        expect(result.ok).toBe(false);
+        console.log("result.aggregateError?.message", result.aggregateError?.message);
+        expect(result.aggregateError?.message).toMatchInlineSnapshot(`
+            "workspaces-to-typescript-project-references found 1 errors.
+
+            - This package is deduplicated in dependencies and devDependencies: @example/invalid
+
+            Please resolve these error before updates tsconfig.json
+            "
+        `);
+    });
     it("should not includes non-ts package", () => {
         const result = toProjectReferences({
             rootDir: path.join(__dirname, "fixtures/js-ts-mixed-packages"),

--- a/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
+++ b/packages/@monorepo-utils/workspaces-to-typescript-project-references/test/index.test.ts
@@ -89,7 +89,6 @@ describe("toProjectReferences", function () {
             checkOnly: true
         });
         expect(result.ok).toBe(false);
-        console.log("result.aggregateError?.message", result.aggregateError?.message);
         expect(result.aggregateError?.message).toMatchInlineSnapshot(`
             "workspaces-to-typescript-project-references found 1 errors.
 


### PR DESCRIPTION
Add early check for duplicated dependency in `dependencies` and `devDependencies`.

fix #56 